### PR TITLE
Set up a GitHub Actions build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    name: Build & test
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x, 20.x, '*']
+
+    env:
+      WASI_VERSION: 14
+      WASI_SDK_PATH: /tmp/wasi-sdk
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+          fetch-depth: 0
+
+      - name: Install test dependencies
+        run: |
+          sudo apt install xz-utils brotli
+
+      - name: Set up WASI-SDK
+        run: |
+          wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION}.0-linux.tar.gz
+          mkdir -p $WASI_SDK_PATH
+          tar xvf wasi-sdk-*-linux.tar.gz -C $WASI_SDK_PATH --strip-components=1
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: npm install
+
+      - name: Build & test
+        run: wasisdkroot=$WASI_SDK_PATH make
+        env:
+          # Legacy provider required for old webpack version in new Node releases:
+          NODE_OPTIONS: ${{ matrix.node-version != '16.x' && '--openssl-legacy-provider' || '' }}


### PR DESCRIPTION
Hi @SteveSanderson! I'm working on my own fork of this library, and I thought this change might be one that you'd want for yourself - it just automates the build steps from the README, so that every push or PR gets built and tested automatically.

(More generally: I'm intending to extend & use this library myself because I need a non-native XZ library for both browsers & Node.js. That's going to imply quite a few changes throughout to add Node compatibility, and some other related tweaks & updates - since this hasn't been touched in quite a while I'm assuming you're not interested in a wave of PRs for all of that, but do let me know if not and I can contribute it all here instead)